### PR TITLE
fix mdspan in FieldInterpolation.hpp

### DIFF
--- a/include/hFlux/FieldInterpolation.hpp
+++ b/include/hFlux/FieldInterpolation.hpp
@@ -2,6 +2,8 @@
 #include <ranges>
 #include <cmath>
 #include <functional>
+#define MDSPAN_USE_BRACKET_OPERATOR 0
+#include <mdspan/mdspan.hpp>
 #include "common.hpp"
 
 namespace vw=std::ranges::views;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(hflux
   ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_include_directories(hflux PRIVATE "${CMAKE_SOURCE_DIR}/external/mdspan/include/mdspan")
+target_link_libraries(hflux PUBLIC Kokkos::kokkos)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
We need to include the Kokkos headers and link against Kokkos to make it available. This also removes the stale reference in CMake to the headers of the submodule.