### PR TITLE
switch back to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(hflux
   VERSION 0.1)
 
 # Set the C++ standard
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(HDF5 COMPONENTS C CXX)


### PR DESCRIPTION
nvcc (at least in CUDA 12.8) does not support `if consteval` from C++23. Switch back to C++20 for now.